### PR TITLE
Misc/group practitioners in synthetic data

### DIFF
--- a/Misc/tools/synthetic_data_modifier/README.md
+++ b/Misc/tools/synthetic_data_modifier/README.md
@@ -10,10 +10,10 @@ In particular, it does the following:
 
 Output data can then be uploaded into FHIR servers via the `holo_fhir_tool`.
 
-# Installation
+## Installation
 Install with `pipenv install`
 
-# Usage
+## Usage
 ```shell
 synthea_data_modifier.py convert in_dir out_dir [--config config.cfg]
 
@@ -23,7 +23,7 @@ synthea_data_modifier.py convert in_dir out_dir [--config config.cfg]
     --config    path to configuration file (default: config.cfg)
 ```
 
-# Configuration
+## Configuration
 Configure specific input synthea files to be modified with specific imaging study resource information.
 ```cfg
 {
@@ -43,7 +43,7 @@ Configure specific input synthea files to be modified with specific imaging stud
 }
 ```
 
-# Misc: Data Selection From Synthea
+## Misc: Data Selection From Synthea
 Patient data used in this module is obtained from synthea via the following steps:
 1. Generate a large number of data from synthea
 2. Select those containing ImagingStudy resource

--- a/Misc/tools/synthetic_data_modifier/README.md
+++ b/Misc/tools/synthetic_data_modifier/README.md
@@ -20,7 +20,7 @@ synthea_data_modifier.py convert in_dir out_dir [--config config.cfg]
     convert     command to convert contents in_dir to out_dir
     in_dir      path to find synthea generated data
     out_dir     path to write modified data
-    --config    path to configuration file
+    --config    path to configuration file (default: config.cfg)
 ```
 
 # Configuration
@@ -43,3 +43,9 @@ Configure specific input synthea files to be modified with specific imaging stud
 }
 ```
 
+# Misc: Data Selection From Synthea
+Patient data used in this module is obtained from synthea via the following steps:
+1. Generate a large number of data from synthea
+2. Select those containing ImagingStudy resource
+3. Remove files with >750kb size
+4. Pick 11 for use in the program

--- a/Misc/tools/synthetic_data_modifier/config.cfg
+++ b/Misc/tools/synthetic_data_modifier/config.cfg
@@ -1,50 +1,56 @@
 {
-    "patient-01.json": [
-        "left-renal-mass",
-        "862",
-        "pelvis",
-        "https://holoblob.blob.core.windows.net/mock-pacs/left-renal-mass.zip"
-    ],
-    "patient-02.json": [
-        "left-scfe-pelvis-bone",
-        "207",
-        "pelvis",
-        "https://holoblob.blob.core.windows.net/mock-pacs/left-scfe-pelvis-bone.zip"
-    ],
-    "patient-03.json": [
-        "left-scfe-pelvis-soft",
-        "207",
-        "pelvis",
-        "https://holoblob.blob.core.windows.net/mock-pacs/left-scfe-pelvis-soft.zip"
-    ],
-    "patient-04.json": [
-        "normal-abdomen",
-        "327",
-        "abdomen",
-        "https://holoblob.blob.core.windows.net/mock-pacs/normal-abdomen.zip"
-    ],
-    "patient-05.json": [
-        "normal-chest-lung",
-        "273",
-        "chest",
-        "https://holoblob.blob.core.windows.net/mock-pacs/normal-chest-lung.zip"
-    ],
-    "patient-06.json": [
-        "normal-chest-mediastinal",
-        "273",
-        "chest",
-        "https://holoblob.blob.core.windows.net/mock-pacs/normal-chest-mediastinal.zip"
-    ],
-    "patient-07.json": [
-        "normal-pelvis-bone",
-        "132",
-        "pelvis",
-        "https://holoblob.blob.core.windows.net/mock-pacs/normal-pelvis-bone.zip"
-    ],
-    "patient-08.json": [
-        "normal-pelvis-soft",
-        "132",
-        "pelvis",
-        "https://holoblob.blob.core.windows.net/mock-pacs/normal-pelvis-soft.zip"
-    ]
+    "general": {
+        "seed": 12345,
+        "practitioners_per_patient": 3
+    },
+    "imagingStudy": {
+        "patient-01.json": [
+            "left-renal-mass",
+            "862",
+            "pelvis",
+            "https://holoblob.blob.core.windows.net/mock-pacs/left-renal-mass.zip"
+        ],
+        "patient-02.json": [
+            "left-scfe-pelvis-bone",
+            "207",
+            "pelvis",
+            "https://holoblob.blob.core.windows.net/mock-pacs/left-scfe-pelvis-bone.zip"
+        ],
+        "patient-03.json": [
+            "left-scfe-pelvis-soft",
+            "207",
+            "pelvis",
+            "https://holoblob.blob.core.windows.net/mock-pacs/left-scfe-pelvis-soft.zip"
+        ],
+        "patient-04.json": [
+            "normal-abdomen",
+            "327",
+            "abdomen",
+            "https://holoblob.blob.core.windows.net/mock-pacs/normal-abdomen.zip"
+        ],
+        "patient-05.json": [
+            "normal-chest-lung",
+            "273",
+            "chest",
+            "https://holoblob.blob.core.windows.net/mock-pacs/normal-chest-lung.zip"
+        ],
+        "patient-06.json": [
+            "normal-chest-mediastinal",
+            "273",
+            "chest",
+            "https://holoblob.blob.core.windows.net/mock-pacs/normal-chest-mediastinal.zip"
+        ],
+        "patient-07.json": [
+            "normal-pelvis-bone",
+            "132",
+            "pelvis",
+            "https://holoblob.blob.core.windows.net/mock-pacs/normal-pelvis-bone.zip"
+        ],
+        "patient-08.json": [
+            "normal-pelvis-soft",
+            "132",
+            "pelvis",
+            "https://holoblob.blob.core.windows.net/mock-pacs/normal-pelvis-soft.zip"
+        ]
+    }
 }

--- a/Misc/tools/synthetic_data_modifier/synthetic_data_modifier.py
+++ b/Misc/tools/synthetic_data_modifier/synthetic_data_modifier.py
@@ -11,12 +11,12 @@ import string
 
 class ModifySyntheaData:
     def __init__(self, config="config.cfg"):
-        self.config = None
+        self._config = None
         with open(config, "r") as config_f:
-            self.config = json.load(config_f)
-        self._photo_rand = random.Random(self.config["general"]["seed"])
-        self._practitioners_rand = random.Random(self.config["general"]["seed"])
-        self._practitioners_per_patient = self.config["general"][
+            self._config = json.load(config_f)
+        self._photo_rand = random.Random(self._config["general"]["seed"])
+        self._practitioners_rand = random.Random(self._config["general"]["seed"])
+        self._practitioners_per_patient = self._config["general"][
             "practitioners_per_patient"
         ]
 
@@ -166,9 +166,9 @@ class ModifySyntheaData:
 
     def _imaging_study_handler(self, data, filename):
         result = None
-        if filename in self.config["imagingStudy"]:
+        if filename in self._config["imagingStudy"]:
             logging.info("\tIncluding ImagingStudy resource")
-            title, num_instances, display_name, url = self.config["imagingStudy"][
+            title, num_instances, display_name, url = self._config["imagingStudy"][
                 filename
             ]
             result = self._modify_imaging_study(data, num_instances, display_name, url)

--- a/Misc/tools/synthetic_data_modifier/synthetic_data_modifier.py
+++ b/Misc/tools/synthetic_data_modifier/synthetic_data_modifier.py
@@ -14,6 +14,11 @@ class ModifySyntheaData:
         self.config = None
         with open(config, "r") as config_f:
             self.config = json.load(config_f)
+        self._photo_rand = random.Random(self.config["general"]["seed"])
+        self._practitioners_rand = random.Random(self.config["general"]["seed"])
+        self._practitioners_per_patient = self.config["general"][
+            "practitioners_per_patient"
+        ]
 
     def _create_contained_endpoint(self, tag, url):
         endpoint = {
@@ -111,7 +116,7 @@ class ModifySyntheaData:
 
     def _add_photo(self, data):
         gender = None
-        pic_num = random.randrange(100)
+        pic_num = self._photo_rand.randrange(100)
         if "gender" in data["resource"]:
             if data["resource"]["gender"] == "male":
                 gender = "men"
@@ -134,7 +139,11 @@ class ModifySyntheaData:
         """
         logging.info("\tIncluding Patient resource")
         general_practitioners = []
-        for pid in prac_ids:
+
+        selected_practitioners = self._practitioners_rand.sample(
+            prac_ids, self._practitioners_per_patient
+        )
+        for pid in selected_practitioners:
             logging.debug(f"\tAdding generalPractitioner: {pid}")
             general_practitioners.append({"reference": "Practitioner/" + pid})
         data["resource"]["generalPractitioner"] = general_practitioners
@@ -157,19 +166,19 @@ class ModifySyntheaData:
 
     def _imaging_study_handler(self, data, filename):
         result = None
-        if filename in self.config:
+        if filename in self.config["imagingStudy"]:
             logging.info("\tIncluding ImagingStudy resource")
-            title, num_instances, display_name, url = self.config[filename]
+            title, num_instances, display_name, url = self.config["imagingStudy"][
+                filename
+            ]
             result = self._modify_imaging_study(data, num_instances, display_name, url)
         return result
 
     def convert(self, in_dir, out_dir):
+        practitioner_ids = []
+
         for filepath in sorted(glob.glob(os.path.join(in_dir, "*.json"))):
-            logging.info(f"Processing: {filepath}")
-            data = None
-            entry_data = []
-            practitioner_ids = []
-            already_included_img_study = False
+            logging.info(f"PreProcessing: {filepath}")
             with open(filepath, "r") as read_patient_file:
                 data = json.load(read_patient_file)
 
@@ -180,6 +189,14 @@ class ModifySyntheaData:
                     pid = resource["resource"]["id"]
                     practitioner_ids.append(pid)
                     logging.debug(f"Found practitioner: {pid}")
+
+        for filepath in sorted(glob.glob(os.path.join(in_dir, "*.json"))):
+            logging.info(f"Processing: {filepath}")
+            data = None
+            entry_data = []
+            already_included_img_study = False
+            with open(filepath, "r") as read_patient_file:
+                data = json.load(read_patient_file)
 
             # Actual processing
             for resource in data["entry"]:

--- a/Misc/tools/synthetic_data_modifier/synthetic_data_modifier.py
+++ b/Misc/tools/synthetic_data_modifier/synthetic_data_modifier.py
@@ -140,9 +140,12 @@ class ModifySyntheaData:
         logging.info("\tIncluding Patient resource")
         general_practitioners = []
 
-        selected_practitioners = self._practitioners_rand.sample(
-            prac_ids, self._practitioners_per_patient
-        )
+        if self._practitioners_per_patient > len(prac_ids):
+            sample_size = len(prac_ids)
+        else:
+            sample_size = self._practitioners_per_patient
+
+        selected_practitioners = self._practitioners_rand.sample(prac_ids, sample_size)
         for pid in selected_practitioners:
             logging.debug(f"\tAdding generalPractitioner: {pid}")
             general_practitioners.append({"reference": "Practitioner/" + pid})
@@ -189,6 +192,11 @@ class ModifySyntheaData:
                     pid = resource["resource"]["id"]
                     practitioner_ids.append(pid)
                     logging.debug(f"Found practitioner: {pid}")
+
+        if self._practitioners_per_patient > len(practitioner_ids):
+            logging.warning(
+                f"Insufficient practitioners to assign per patient: {len(practitioner_ids)} found"
+            )
 
         for filepath in sorted(glob.glob(os.path.join(in_dir, "*.json"))):
             logging.info(f"Processing: {filepath}")


### PR DESCRIPTION
PR generates generalPractitioner field using a pool of all found practitioners in the input dataset. Instead of what's found within a single patient's data.

This feature is created because the dataset does not provide enough overlap of practitioners per patients.