### PR TITLE
Storage/fixes and api update

### DIFF
--- a/HoloStorageAccessor/api/CHANGELOG.md
+++ b/HoloStorageAccessor/api/CHANGELOG.md
@@ -4,6 +4,12 @@ All changes done to the HoloStorage Accessor API spec will be documented here.
 View the interactive documentation of the most updated API at the following link:
 https://app.swaggerhub.com/apis/boonwj/HoloRepository/
 
+## [1.1.0] - 2019-08-08
+### Changed
+- `GET /patients` query parameter change from `pid` to `pids`
+- `GET /authors` query parameter change from `aid` to `aids`
+- `GET /holograms` query parameter change from `hid` to `hids` and `pid` to `pids`
+
 ## [1.0.1] - 2019-08-08
 ### Changed
 - `GET /patients`, `GET /holograms` and `GET /authors` to return 400 error when no query parameters are provided

--- a/HoloStorageAccessor/api/CHANGELOG.md
+++ b/HoloStorageAccessor/api/CHANGELOG.md
@@ -4,6 +4,10 @@ All changes done to the HoloStorage Accessor API spec will be documented here.
 View the interactive documentation of the most updated API at the following link:
 https://app.swaggerhub.com/apis/boonwj/HoloRepository/
 
+## [1.0.1] - 2019-08-08
+### Changed
+- `GET /patients`, `GET /holograms` and `GET /authors` to return 400 error when no query parameters are provided
+
 ## [1.0.0] - 2019-08-05
 ### Changed
 - Update api description to be more explict with the return results of mass queries of `holograms`, `authors` and `patients`

--- a/HoloStorageAccessor/api/openapi.yaml
+++ b/HoloStorageAccessor/api/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 info:
-  version: "1.0.0"
+  version: "1.1.0"
   title: 'HoloStorage Accessor API'
   description: 'API to access holograms and metadata from HoloStorage'
 

--- a/HoloStorageAccessor/api/openapi.yaml
+++ b/HoloStorageAccessor/api/openapi.yaml
@@ -13,8 +13,6 @@ paths:
 
         Multiple IDs can be passed with the syntax `/patients?pid=id1,id2,id3,...,idx`
 
-        Not querying any `pid` will result in an empty result set.
-
         Mass query results will return with `ID:{result}`
         ```
         {
@@ -35,6 +33,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Patients'
+        400:
+          $ref: '#/components/responses/BadRequest'
         500:
           $ref: "#/components/responses/InternalError"
 
@@ -91,8 +91,6 @@ paths:
         **Note: You can only use either hid or pid**
 
         Additional filtering for CreationMode can be done with `&creationmode=...`
-
-        Not querying either `?pid` or `?hid` will result in an empty result set.
 
         Regardless of `pid` or `hid` queries, mass query results will return a format of `ID:[{result}]`
         ```
@@ -207,8 +205,6 @@ paths:
 
         Multiple IDs can be passed with the syntax `/authors?aid=id1,id2,id3,...,idx`
 
-        Not querying any `aid` will result in an empty result set.
-
         Mass query results will return with `ID:{result}`
         ```
         {
@@ -229,6 +225,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Authors'
+        400:
+          $ref: '#/components/responses/BadRequest'
         500:
           $ref: "#/components/responses/InternalError"
 

--- a/HoloStorageAccessor/api/openapi.yaml
+++ b/HoloStorageAccessor/api/openapi.yaml
@@ -11,7 +11,7 @@ paths:
       description: |-
         Obtain patient information stored within HoloStorage.
 
-        Multiple IDs can be passed with the syntax `/patients?pid=id1,id2,id3,...,idx`
+        Multiple IDs can be passed with the syntax `/patients?pids=id1,id2,id3,...,idx`
 
         Mass query results will return with `ID:{result}`
         ```
@@ -86,7 +86,7 @@ paths:
 
         Multiple IDs can be passed with either syntax:
 
-        `/holograms?hid=id1,id2,id3,...,idx` or `/holograms?pid=id1,id2,id3,...,idx`
+        `/holograms?hids=id1,id2,id3,...,idx` or `/holograms?pids=id1,id2,id3,...,idx`
 
         **Note: You can only use either hid or pid**
 
@@ -203,7 +203,7 @@ paths:
       description: |-
         Obtain author information stored within HoloStorage.
 
-        Multiple IDs can be passed with the syntax `/authors?aid=id1,id2,id3,...,idx`
+        Multiple IDs can be passed with the syntax `/authors?aids=id1,id2,id3,...,idx`
 
         Mass query results will return with `ID:{result}`
         ```
@@ -295,7 +295,7 @@ components:
   parameters:
     PIDQuery:
       in: query
-      name: pid
+      name: pids
       schema:
         type: string
         format: uuid
@@ -316,7 +316,7 @@ components:
 
     HIDQuery:
       in: query
-      name: hid
+      name: hids
       schema:
         type: string
         format: uuid
@@ -349,7 +349,7 @@ components:
 
     AIDQuery:
       in: query
-      name: aid
+      name: aids
       schema:
         type: string
         format: uuid

--- a/HoloStorageAccessor/internal/holostorageaccessor/api_default.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/api_default.go
@@ -78,8 +78,14 @@ func AuthorsAidPut(c *gin.Context) {
 
 // AuthorsGet - Mass query for author metadata in HoloStorage
 func AuthorsGet(c *gin.Context) {
+	aids := c.Query("aid")
+	if aids == "" {
+		c.JSON(http.StatusBadRequest, Error{ErrorCode: "400", ErrorMessage: "No aids were provided for this query"})
+		return
+	}
+
 	fhirRequests := make(map[string]FHIRRequest)
-	ids := ParseQueryIDs(c.Query("aid"))
+	ids := ParseQueryIDs(aids)
 
 	for _, id := range ids {
 		fhirURL, _ := ConstructURL(accessorConfig.FhirURL, "Practitioner/"+id)
@@ -343,8 +349,14 @@ func HologramsPost(c *gin.Context) {
 
 // PatientsGet - Mass query for patients metadata in HoloStorage
 func PatientsGet(c *gin.Context) {
+	pids := c.Query("pid")
+	if pids == "" {
+		c.JSON(http.StatusBadRequest, Error{ErrorCode: "400", ErrorMessage: "No pids were provided for this query"})
+		return
+	}
+
 	fhirRequests := make(map[string]FHIRRequest)
-	ids := ParseQueryIDs(c.Query("pid"))
+	ids := ParseQueryIDs(pids)
 
 	for _, id := range ids {
 		fhirURL, _ := ConstructURL(accessorConfig.FhirURL, "Patient/"+id)

--- a/HoloStorageAccessor/internal/holostorageaccessor/api_default.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/api_default.go
@@ -78,7 +78,7 @@ func AuthorsAidPut(c *gin.Context) {
 
 // AuthorsGet - Mass query for author metadata in HoloStorage
 func AuthorsGet(c *gin.Context) {
-	aids := c.Query("aid")
+	aids := c.Query("aids")
 	if aids == "" {
 		c.JSON(http.StatusBadRequest, Error{ErrorCode: "400", ErrorMessage: "No aids were provided for this query"})
 		return
@@ -115,10 +115,10 @@ func AuthorsGet(c *gin.Context) {
 
 // HologramsGet - Mass query for hologram metadata based on hologram ids
 func HologramsGet(c *gin.Context) {
-	hid := c.Query("hid")
-	pid := c.Query("pid")
+	hids := c.Query("hids")
+	pids := c.Query("pids")
 	creationMode := c.Query("creationmode")
-	details, err := VerifyHologramQuery(hid, pid, creationMode)
+	details, err := VerifyHologramQuery(hids, pids, creationMode)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, Error{ErrorCode: "400", ErrorMessage: err.Error()})
 		return
@@ -349,7 +349,7 @@ func HologramsPost(c *gin.Context) {
 
 // PatientsGet - Mass query for patients metadata in HoloStorage
 func PatientsGet(c *gin.Context) {
-	pids := c.Query("pid")
+	pids := c.Query("pids")
 	if pids == "" {
 		c.JSON(http.StatusBadRequest, Error{ErrorCode: "400", ErrorMessage: "No pids were provided for this query"})
 		return

--- a/HoloStorageAccessor/internal/holostorageaccessor/blob_storage_client.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/blob_storage_client.go
@@ -31,8 +31,8 @@ func InitialiseBlobStorage(accountName, accountKey string) error {
 
 	_, err = blobContainerURL.Create(ctx, azblob.Metadata{}, azblob.PublicAccessNone)
 	if err != nil {
-		if serr, ok := err.(azblob.StorageError); ok {
-			switch serr.ServiceCode() {
+		if serviceErr, ok := err.(azblob.StorageError); ok {
+			switch serviceErr.ServiceCode() {
 			case azblob.ServiceCodeContainerAlreadyExists:
 				log.Printf("Blob container %q already exists.", containerName)
 				return nil

--- a/HoloStorageAccessor/internal/holostorageaccessor/routers.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/routers.go
@@ -36,7 +36,7 @@ type AccessorConfig struct {
 	BlobStorageKey  string
 }
 
-var basePathComponent = "/api/1.0.0/"
+var basePathComponent = "/api/v1/"
 var uiPath = basePathComponent + "ui/"
 var accessorConfig AccessorConfig
 

--- a/HoloStorageAccessor/internal/holostorageaccessor/utils.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/utils.go
@@ -34,7 +34,7 @@ func ParseHologramUploadPostInput(formData url.Values) (HologramPostInput, error
 		case "patient":
 			err := json.Unmarshal([]byte(formData.Get(key)), &patientData)
 			if err != nil {
-				return HologramPostInput{}, errors.New("Unable to prase patient data")
+				return HologramPostInput{}, errors.New("Unable to parse patient data")
 			}
 			if patientData.Pid == "" {
 				return HologramPostInput{}, errors.New("Patient ID is required")
@@ -43,7 +43,7 @@ func ParseHologramUploadPostInput(formData url.Values) (HologramPostInput, error
 		case "author":
 			err := json.Unmarshal([]byte(formData.Get(key)), &authorData)
 			if err != nil {
-				return HologramPostInput{}, errors.New("Unable to prase author data")
+				return HologramPostInput{}, errors.New("Unable to parse author data")
 			}
 			if authorData.Aid == "" {
 				return HologramPostInput{}, errors.New("Author ID is required")

--- a/HoloStorageAccessor/internal/holostorageaccessor/utils.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/utils.go
@@ -96,6 +96,8 @@ func VerifyHologramQuery(hid, pid, creationMode string) (HologramQueryDetails, e
 	var details HologramQueryDetails
 	if hid != "" && pid != "" {
 		return HologramQueryDetails{}, errors.New("Use either pid or hid, not both")
+	} else if hid == "" && pid == "" {
+		return HologramQueryDetails{}, errors.New("No hids or pids were provided for this query")
 	} else if hid != "" {
 		details.IDs = ParseQueryIDs(hid)
 		details.Mode = "hologram"

--- a/HoloStorageAccessor/internal/holostorageaccessor/utils.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/utils.go
@@ -50,17 +50,23 @@ func ParseHologramUploadPostInput(formData url.Values) (HologramPostInput, error
 			}
 			hologramData.Aid = authorData.Aid
 		case "creationDate":
-			creationDate, err := time.Parse(time.RFC3339, formData.Get(key))
-			if err != nil {
-				return HologramPostInput{}, fmt.Errorf("Key %s='%s' does not conform to RFC3339 standards", key, formData.Get(key))
+			dateString := formData.Get(key)
+			if dateString != "" {
+				creationDate, err := time.Parse(time.RFC3339, dateString)
+				if err != nil {
+					return HologramPostInput{}, fmt.Errorf("Key %s='%s' does not conform to RFC3339 standards", key, formData.Get(key))
+				}
+				hologramData.CreationDate = &creationDate
 			}
-			hologramData.CreationDate = &creationDate
 		case "dateOfImaging":
-			dateOfImaging, err := time.Parse(time.RFC3339, formData.Get(key))
-			if err != nil {
-				return HologramPostInput{}, fmt.Errorf("Key %s='%s' does not conform to RFC3339 standards", key, formData.Get(key))
+			dateString := formData.Get(key)
+			if dateString != "" {
+				dateOfImaging, err := time.Parse(time.RFC3339, dateString)
+				if err != nil {
+					return HologramPostInput{}, fmt.Errorf("Key %s='%s' does not conform to RFC3339 standards", key, formData.Get(key))
+				}
+				hologramData.DateOfImaging = &dateOfImaging
 			}
-			hologramData.DateOfImaging = &dateOfImaging
 		case "title":
 			hologramData.Title = formData.Get(key)
 		case "description":

--- a/HoloStorageAccessor/internal/holostorageaccessor/utils.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/utils.go
@@ -112,7 +112,7 @@ func VerifyHologramQuery(hid, pid, creationMode string) (HologramQueryDetails, e
 	case "GENERATE_FROM_IMAGING_STUDY", "UPLOAD_EXISTING_MODEL", "FROM_DEPTHVISOR_RECORDING":
 		details.CreationMode = creationMode
 	default:
-		return HologramQueryDetails{}, errors.New("Invalid value used in creationmode")
+		return HologramQueryDetails{}, errors.New(`Invalid value used in creationmode. Expecting: GENERATE_FROM_IMAGING_STUDY, UPLOAD_EXISTING_MODEL, FROM_DEPTHVISOR_RECORDING`)
 	}
 
 	return details, nil

--- a/HoloStorageAccessor/internal/holostorageaccessor/utils_test.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/utils_test.go
@@ -69,14 +69,14 @@ func TestVerifyHologramQuery(t *testing.T) {
 	}
 
 	tests := map[string]test{
-		"no_input":                             {in_hid: "", in_pid: "", in_creationMode: "", want_details: HologramQueryDetails{}},
+		"no_input":                             {in_hid: "", in_pid: "", in_creationMode: "", want_details: HologramQueryDetails{}, want_err: "No hids or pids were provided for this query"},
 		"hid_only":                             {in_hid: "h1,h2", in_pid: "", in_creationMode: "", want_details: HologramQueryDetails{IDs: []string{"h1", "h2"}, Mode: "hologram"}},
 		"pid_only":                             {in_hid: "", in_pid: "p1,p2", in_creationMode: "", want_details: HologramQueryDetails{IDs: []string{"p1", "p2"}, Mode: "patient"}},
 		"both_hid_and_pid":                     {in_hid: "h1,h2", in_pid: "p1,p2", in_creationMode: "", want_details: HologramQueryDetails{}, want_err: "Use either pid or hid, not both"},
-		"creation_generate_from_imaging_study": {in_hid: "", in_pid: "", in_creationMode: "GENERATE_FROM_IMAGING_STUDY", want_details: HologramQueryDetails{CreationMode: "GENERATE_FROM_IMAGING_STUDY"}},
-		"creation_upload_existing_model":       {in_hid: "", in_pid: "", in_creationMode: "UPLOAD_EXISTING_MODEL", want_details: HologramQueryDetails{CreationMode: "UPLOAD_EXISTING_MODEL"}},
-		"creation_from_depthvisor_recording":   {in_hid: "", in_pid: "", in_creationMode: "FROM_DEPTHVISOR_RECORDING", want_details: HologramQueryDetails{CreationMode: "FROM_DEPTHVISOR_RECORDING"}},
-		"creation_invalid":                     {in_hid: "", in_pid: "", in_creationMode: "invalid", want_details: HologramQueryDetails{}, want_err: "Invalid value used in creationmode"},
+		"creation_generate_from_imaging_study": {in_hid: "", in_pid: "p1", in_creationMode: "GENERATE_FROM_IMAGING_STUDY", want_details: HologramQueryDetails{IDs: []string{"p1"}, Mode: "patient", CreationMode: "GENERATE_FROM_IMAGING_STUDY"}},
+		"creation_upload_existing_model":       {in_hid: "", in_pid: "p1", in_creationMode: "UPLOAD_EXISTING_MODEL", want_details: HologramQueryDetails{IDs: []string{"p1"}, Mode: "patient", CreationMode: "UPLOAD_EXISTING_MODEL"}},
+		"creation_from_depthvisor_recording":   {in_hid: "", in_pid: "p1", in_creationMode: "FROM_DEPTHVISOR_RECORDING", want_details: HologramQueryDetails{IDs: []string{"p1"}, Mode: "patient", CreationMode: "FROM_DEPTHVISOR_RECORDING"}},
+		"creation_invalid":                     {in_hid: "", in_pid: "p1", in_creationMode: "invalid", want_details: HologramQueryDetails{}, want_err: "Invalid value used in creationmode. Expecting: GENERATE_FROM_IMAGING_STUDY, UPLOAD_EXISTING_MODEL, FROM_DEPTHVISOR_RECORDING"},
 	}
 
 	for name, tc := range tests {

--- a/HoloStorageAccessor/test/HoloStorageAccessor.postman_collection.json
+++ b/HoloStorageAccessor/test/HoloStorageAccessor.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "31b4dd38-5118-4d12-a2f8-8aba30a573a9",
-		"name": "HoloAccessor",
+		"_postman_id": "b541d019-db14-4a93-862e-ee42074bee11",
+		"name": "HoloStorageAccessor",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -22,14 +22,14 @@
 					"raw": "{\n    \"aid\": \"a1000\",\n    \"name\": {\n    \t\"full\": \"Roy Campbell\",\n        \"title\": \"Mr.\",\n        \"given\": \"Roy\",\n        \"family\": \"Campbell\"\n    }\n}"
 				},
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/authors/a1000",
+					"raw": "localhost:3200/api/v1/authors/a1000",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"authors",
 						"a1000"
 					]
@@ -44,16 +44,16 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/authors/a-1000",
+					"raw": "localhost:3200/api/v1/authors/a1000",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"authors",
-						"a-1000"
+						"a1000"
 					]
 				}
 			},
@@ -65,20 +65,20 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/authors?aid=a1000,a-100,a-101,a-102",
+					"raw": "localhost:3200/api/v1/authors?aids=a1000,a100,a101,a102",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"authors"
 					],
 					"query": [
 						{
-							"key": "aid",
-							"value": "a1000,a-100,a-101,a-102"
+							"key": "aids",
+							"value": "a1000,a100,a101,a102"
 						}
 					]
 				}
@@ -99,19 +99,19 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"pid\": \"p111\",\n    \"name\": {\n        \"title\": \"Mr.\",\n        \"given\": \"Timothy\",\n        \"family\": \"Jones\",\n        \"full\": \"Timothy Jones\"\n    },\n    \"gender\": \"male\",\n    \"birthDate\": \"1990-10-10\"\n}"
+					"raw": "{\n    \"pid\": \"p1000\",\n    \"name\": {\n        \"title\": \"Mr.\",\n        \"given\": \"Timothy\",\n        \"family\": \"Jones\",\n        \"full\": \"Timothy Jones\"\n    },\n    \"gender\": \"male\",\n    \"birthDate\": \"1990-10-10\"\n}"
 				},
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/patients/p111",
+					"raw": "localhost:3200/api/v1/patients/p1000",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"patients",
-						"p111"
+						"p1000"
 					]
 				}
 			},
@@ -123,16 +123,16 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/authors/a1000",
+					"raw": "localhost:3200/api/v1/patients/p1000",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
-						"authors",
-						"a1000"
+						"v1",
+						"patients",
+						"p1000"
 					]
 				}
 			},
@@ -144,20 +144,20 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/patients?pid=p111,p112,p113,p100,p1010101",
+					"raw": "localhost:3200/api/v1/patients?pids=p1000,p100,p101,p102,p103",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"patients"
 					],
 					"query": [
 						{
-							"key": "pid",
-							"value": "p111,p112,p113,p100,p1010101"
+							"key": "pids",
+							"value": "p1000,p100,p101,p102,p103"
 						}
 					]
 				}
@@ -248,14 +248,14 @@
 					]
 				},
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/holograms",
+					"raw": "localhost:3200/api/v1/holograms",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"holograms"
 					]
 				}
@@ -268,14 +268,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/holograms/hid-from-post-method",
+					"raw": "localhost:3200/api/v1/holograms/hid-from-post-method",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"holograms",
 						"hid-from-post-method"
 					]
@@ -290,20 +290,20 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/holograms?hid=h-100,h-101,h-102,h-103,h-104,",
+					"raw": "localhost:3200/api/v1/holograms?hids=h100,h101,h102,h103,h104,",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"holograms"
 					],
 					"query": [
 						{
-							"key": "hid",
-							"value": "h-100,h-101,h-102,h-103,h-104,"
+							"key": "hids",
+							"value": "h100,h101,h102,h103,h104,"
 						}
 					]
 				}
@@ -316,20 +316,20 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/holograms?pid=p-101,p-102,p-103,p-104",
+					"raw": "localhost:3200/api/v1/holograms?pids=p101,p102,p103,p104",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"holograms"
 					],
 					"query": [
 						{
-							"key": "pid",
-							"value": "p-101,p-102,p-103,p-104"
+							"key": "pids",
+							"value": "p101,p102,p103,p104"
 						}
 					]
 				}
@@ -342,20 +342,20 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/holograms?pid=p-500&creationmode=UPLOAD_EXISTING_MODEL",
+					"raw": "localhost:3200/api/v1/holograms?pids=p500&creationmode=UPLOAD_EXISTING_MODEL",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"holograms"
 					],
 					"query": [
 						{
-							"key": "pid",
-							"value": "p-500"
+							"key": "pids",
+							"value": "p500"
 						},
 						{
 							"key": "creationmode",
@@ -372,16 +372,16 @@
 				"method": "DELETE",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/holograms/use-hid-from-post-method",
+					"raw": "localhost:3200/api/v1/holograms/hid-from-post-method",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"holograms",
-						"use-hid-from-post-method"
+						"hid-from-post-method"
 					]
 				}
 			},
@@ -393,14 +393,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:3200/api/1.0.0/holograms/hid-from-post-method/download",
+					"raw": "localhost:3200/api/v1/holograms/hid-from-post-method/download",
 					"host": [
 						"localhost"
 					],
 					"port": "3200",
 					"path": [
 						"api",
-						"1.0.0",
+						"v1",
 						"holograms",
 						"hid-from-post-method",
 						"download"


### PR DESCRIPTION
This PR brings about multiple small fixes and an update to the API spec. 

@fanbomeng97  and @nbckr: Note that this PR may include breaking changes to your code. 

## Fixes
- Spellcheck errors (e.g. parse)
- Ignore empty string datetime values passed in `POST /holograms` endpoint
- Postman request collection errors  

## API changes
- v1.0.1 Return 400 errors when no id values are found in multi-query endpoints 
- v1.1.0 Change ID names for multi-query endpoints to their plural variants (e.g. aids, pids, hids)

## Misc
- Change base api endpoint from /api/1.0.0 to /api/v1. This reduces ambiguity with the updated api versions.
