### PR TITLE
STORAGE: Access-Control-Allow-Origin: *

### DIFF
--- a/HoloStorageAccessor/README.md
+++ b/HoloStorageAccessor/README.md
@@ -83,6 +83,7 @@ If not, `export` the variables before running the program.
 | ACCESSOR_FHIR_URL        | URL to the FHIR server that accessor connects to |
 | AZURE_STORAGE_ACCOUNT    | Name of blob store for holograms                 |
 | AZURE_STORAGE_ACCESS_KEY | Access key to the blob store                     |
+| ENABLE_CORS              | Enable CORS support for accessor                 |
 
 
 ## Contact and support

--- a/HoloStorageAccessor/config.env
+++ b/HoloStorageAccessor/config.env
@@ -1,3 +1,4 @@
 AZURE_STORAGE_ACCOUNT=blobstoragename
 AZURE_STORAGE_ACCESS_KEY=storageaccesskey
 ACCESSOR_FHIR_URL=http://fhir.website.com
+ENABLE_CORS=true

--- a/HoloStorageAccessor/internal/holostorageaccessor/routers.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/routers.go
@@ -53,6 +53,8 @@ func NewRouter() *gin.Engine {
 
 	router := gin.Default()
 
+	router.Use(cors.Default())
+
 	router.Static(uiPath, "./third_party/swaggerui")
 
 	for _, route := range routes {
@@ -67,8 +69,6 @@ func NewRouter() *gin.Engine {
 			router.DELETE(route.Pattern, route.HandlerFunc)
 		}
 	}
-
-	router.Use(cors.Default())
 
 	log.Printf("HoloStorageAccessor is running!")
 	return router

--- a/HoloStorageAccessor/internal/holostorageaccessor/routers.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/routers.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -66,6 +67,8 @@ func NewRouter() *gin.Engine {
 			router.DELETE(route.Pattern, route.HandlerFunc)
 		}
 	}
+
+	router.Use(cors.Default())
 
 	log.Printf("HoloStorageAccessor is running!")
 	return router

--- a/HoloStorageAccessor/internal/holostorageaccessor/routers.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/routers.go
@@ -35,6 +35,7 @@ type AccessorConfig struct {
 	FhirURL         string
 	BlobStorageName string
 	BlobStorageKey  string
+	EnableCORS      bool
 }
 
 var basePathComponent = "/api/v1/"
@@ -50,10 +51,13 @@ func NewRouter() *gin.Engine {
 
 	log.Printf("FHIR Backend URL: %q", accessorConfig.FhirURL)
 	log.Printf("Blob Store: %q", accessorConfig.BlobStorageName)
+	log.Printf("CORS Enabled: %t", accessorConfig.EnableCORS)
 
 	router := gin.Default()
 
-	router.Use(cors.Default())
+	if accessorConfig.EnableCORS {
+		router.Use(cors.Default())
+	}
 
 	router.Static(uiPath, "./third_party/swaggerui")
 

--- a/HoloStorageAccessor/internal/holostorageaccessor/utils.go
+++ b/HoloStorageAccessor/internal/holostorageaccessor/utils.go
@@ -144,7 +144,7 @@ func ConstructURL(baseurl string, pathComponent string) (string, error) {
 }
 
 func LoadConfiguration(config *AccessorConfig) error {
-	for _, config := range []string{"AZURE_STORAGE_ACCOUNT", "AZURE_STORAGE_ACCESS_KEY", "ACCESSOR_FHIR_URL"} {
+	for _, config := range []string{"AZURE_STORAGE_ACCOUNT", "AZURE_STORAGE_ACCESS_KEY", "ACCESSOR_FHIR_URL", "ENABLE_CORS"} {
 		if os.Getenv(config) == "" {
 			return fmt.Errorf("Environment config field '%s' is not set", config)
 		}
@@ -154,7 +154,13 @@ func LoadConfiguration(config *AccessorConfig) error {
 	config.BlobStorageKey = strings.TrimSpace(os.Getenv("AZURE_STORAGE_ACCESS_KEY"))
 	config.FhirURL = strings.TrimSpace(os.Getenv("ACCESSOR_FHIR_URL"))
 
-	_, err := url.ParseRequestURI(config.FhirURL)
+	enableCORS, err := strconv.ParseBool(strings.TrimSpace(os.Getenv("ENABLE_CORS")))
+	if err != nil {
+		return fmt.Errorf("Error with ENABLE_CORS: %s", err.Error())
+	}
+	config.EnableCORS = enableCORS
+
+	_, err = url.ParseRequestURI(config.FhirURL)
 	if err != nil {
 		return fmt.Errorf("Error with ACCESSOR_FHIR_URL: %s", err.Error())
 	}


### PR DESCRIPTION
This is needed to allow redirection from the UI.

The current solution to redirect all hologram-related requests directly to the Accessor is not ideal and might be refactored if time allows. However, at least for the `/download` endpoint, this solution makes sense. So for now, I suggest we do `Access-Control-Allow-Origin: *` for the Accessor.