### PR TITLE
PIPELINE: rescaling for rest of the pipelines

### DIFF
--- a/HoloPipelines/config.ini
+++ b/HoloPipelines/config.ini
@@ -1,0 +1,2 @@
+[DEFAULT]
+Marching_cube_resolution_limit = 256

--- a/HoloPipelines/pipelineList.json
+++ b/HoloPipelines/pipelineList.json
@@ -42,6 +42,6 @@
          "info":"Generate 3D models (8 in total) for the organs in the abdomen region",
          "addDate":"07/08/2019",
          "modDate":"07/08/2019",
-         "param":"4"
+         "param":"3"
       }
 }

--- a/HoloPipelines/pipelines/components/compDicom2numpy.py
+++ b/HoloPipelines/pipelines/components/compDicom2numpy.py
@@ -88,7 +88,7 @@ def reorientateNumpyList(numpyList):
     # transpose numpy i.e. (z, y, x) ---> (x, y, z)
     numpyList = numpyList.transpose(2, 1, 0)
     numpyList = np.flip(numpyList, 0)
-    numpyList = np.flip(numpyList, 1)
+    # numpyList = np.flip(numpyList, 1) # need to confirm this
     return numpyList
 
 

--- a/HoloPipelines/pipelines/components/compDicom2numpy.py
+++ b/HoloPipelines/pipelines/components/compDicom2numpy.py
@@ -88,7 +88,6 @@ def reorientateNumpyList(numpyList):
     # transpose numpy i.e. (z, y, x) ---> (x, y, z)
     numpyList = numpyList.transpose(2, 1, 0)
     numpyList = np.flip(numpyList, 0)
-    # numpyList = np.flip(numpyList, 1) # need to confirm this
     return numpyList
 
 

--- a/HoloPipelines/pipelines/components/compNumpy2obj.py
+++ b/HoloPipelines/pipelines/components/compNumpy2obj.py
@@ -38,6 +38,7 @@ def generateObj(inputNumpy, thisThreshold, outputObjPath):
             )
 
     verts, faces, norm = generateMesh(numpyData, float(thisThreshold), 1)
+    logging.info("number of faces generated: " + str(len(faces)))
 
     faces = (
         faces + 1

--- a/HoloPipelines/pipelines/components/compNumpyTransformation.py
+++ b/HoloPipelines/pipelines/components/compNumpyTransformation.py
@@ -1,6 +1,20 @@
 import scipy.ndimage
 import sys
 import logging
+import configparser
+import pathlib
+import os
+
+config = configparser.ConfigParser()
+config.sections()
+config.read(
+    str(
+        pathlib.Path(str(os.path.dirname(os.path.realpath(__file__))))
+        .parents[1]
+        .joinpath("config.ini")
+    )
+)
+default_resolution_limit = config["DEFAULT"]["Marching_cube_resolution_limit"]
 
 logging.basicConfig(level=logging.INFO)
 
@@ -19,7 +33,7 @@ def centerCrop(img, newX, newY, newZ):
     return img[startX:endX, startY:endY, startZ:endZ]
 
 
-def sizeLimit(img, limit):
+def sizeLimit(img, limit=default_resolution_limit):
     if len(img.shape) >= 3:
         x = img.shape[0]
         y = img.shape[1]

--- a/HoloPipelines/pipelines/components/compNumpyTransformation.py
+++ b/HoloPipelines/pipelines/components/compNumpyTransformation.py
@@ -40,7 +40,9 @@ def sizeLimit(img, limit):
         if highest > limit:
             img = centerCrop(img, limit, limit, limit)
 
-        logging.info("compNumpyTransformation: array resize done")
+        logging.info(
+            "compNumpyTransformation: array resize done. new shape: " + repr(img.shape)
+        )
     else:
         logging.info(
             "compNumpyTransformation: array smaller than limit given, no resize has been done"

--- a/HoloPipelines/pipelines/components/compNumpyTransformation.py
+++ b/HoloPipelines/pipelines/components/compNumpyTransformation.py
@@ -14,7 +14,7 @@ config.read(
         .joinpath("config.ini")
     )
 )
-default_resolution_limit = config["DEFAULT"]["Marching_cube_resolution_limit"]
+default_resolution_limit = int(config["DEFAULT"]["Marching_cube_resolution_limit"])
 
 logging.basicConfig(level=logging.INFO)
 

--- a/HoloPipelines/pipelines/pipelineAbdomenDicom2glb.py
+++ b/HoloPipelines/pipelines/pipelineAbdomenDicom2glb.py
@@ -10,9 +10,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 
 
-def main(
-    inputDicomPath, outputGlbFolderPath, segmentationModelUrl, resolutionLimit=300
-):
+def main(inputDicomPath, outputGlbFolderPath, segmentationModelUrl):
     generatedNiftiPath = compDicom2nifti.main(
         inputDicomPath, str(compCommonPath.nifti.joinpath("_temp.nii"))
     )
@@ -24,9 +22,7 @@ def main(
     generatedNumpyList = compNifti2numpy.main(
         segmentedNiftiPath, deleteNiftiWhenDone=True
     )
-    resizedNumpyList = compNumpyTransformation.sizeLimit(
-        generatedNumpyList, resolutionLimit
-    )
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList)
     generatedGlbPathList = compSeparateNumpy.main(resizedNumpyList, outputGlbFolderPath)
     logging.info(
         "abdomenDicom2glb: done, glb models generated at "
@@ -35,4 +31,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main(sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4]))
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/HoloPipelines/pipelines/pipelineDicom2glb.py
+++ b/HoloPipelines/pipelines/pipelineDicom2glb.py
@@ -2,17 +2,21 @@ from components import compCommonPath
 from components import compDicom2numpy
 from components import compNumpy2obj
 from components import compObj2glbWrapper
+from components import compNumpyTransformation
 import pathlib
 import sys
 import logging
+import datetime
 
 logging.basicConfig(level=logging.INFO)
 
 
 def main(dicomFolderPath, outputGlbPath, threshold):
     generatedNumpyList = compDicom2numpy.main(str(pathlib.Path(dicomFolderPath)))
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList, limit=256)
+    start = datetime.datetime.now()
     generatedObjPath = compNumpy2obj.main(
-        generatedNumpyList,
+        resizedNumpyList,
         threshold,
         str(
             compCommonPath.obj.joinpath(
@@ -20,6 +24,11 @@ def main(dicomFolderPath, outputGlbPath, threshold):
             )
         )
         + ".obj",
+    )
+    end = datetime.datetime.now()
+    diff = end - start
+    logging.info(
+        "time taken for marching cubes:  " + str(diff.total_seconds()) + " seconds"
     )
     generatedGlbPath = compObj2glbWrapper.main(
         generatedObjPath, outputGlbPath, deleteOriginalObj=True, compressGlb=False

--- a/HoloPipelines/pipelines/pipelineDicom2glb.py
+++ b/HoloPipelines/pipelines/pipelineDicom2glb.py
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.INFO)
 
 def main(dicomFolderPath, outputGlbPath, threshold):
     generatedNumpyList = compDicom2numpy.main(str(pathlib.Path(dicomFolderPath)))
-    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList, limit=256)
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList)
     start = datetime.datetime.now()
     generatedObjPath = compNumpy2obj.main(
         resizedNumpyList,

--- a/HoloPipelines/pipelines/pipelineLungDicom2glb.py
+++ b/HoloPipelines/pipelines/pipelineLungDicom2glb.py
@@ -27,7 +27,7 @@ def main(dicomPath, outputGlbPath):
     generatedNumpyList = compNifti2numpy.main(
         str(pathlib.Path(generatedSegmentedLungsNiftiPath).joinpath("lung.nii.gz"))
     )
-    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList, limit=256)
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList)
     generatedObjPath = compNumpy2obj.main(
         resizedNumpyList, 0.5, str(compCommonPath.obj.joinpath("nifti2glb_tempObj.obj"))
     )

--- a/HoloPipelines/pipelines/pipelineLungDicom2glb.py
+++ b/HoloPipelines/pipelines/pipelineLungDicom2glb.py
@@ -3,6 +3,7 @@ from components import compDicom2nifti
 from components import compNifti2numpy
 from components import compNumpy2obj
 from components import compObj2glbWrapper
+from components import compNumpyTransformation
 import components.lungSegment.main as compLungSegment
 import pathlib
 import sys
@@ -26,10 +27,9 @@ def main(dicomPath, outputGlbPath):
     generatedNumpyList = compNifti2numpy.main(
         str(pathlib.Path(generatedSegmentedLungsNiftiPath).joinpath("lung.nii.gz"))
     )
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList, limit=256)
     generatedObjPath = compNumpy2obj.main(
-        generatedNumpyList,
-        0.5,
-        str(compCommonPath.obj.joinpath("nifti2glb_tempObj.obj")),
+        resizedNumpyList, 0.5, str(compCommonPath.obj.joinpath("nifti2glb_tempObj.obj"))
     )
     generatedGlbPath = compObj2glbWrapper.main(
         generatedObjPath,

--- a/HoloPipelines/pipelines/pipelineNifti2glb.py
+++ b/HoloPipelines/pipelines/pipelineNifti2glb.py
@@ -2,6 +2,7 @@ from components import compCommonPath
 from components import compNifti2numpy
 from components import compNumpy2obj
 from components import compObj2glbWrapper
+from components import compNumpyTransformation
 import pathlib
 import sys
 import logging
@@ -11,8 +12,9 @@ logging.basicConfig(level=logging.INFO)
 
 def main(inputNiftiPath, outputGlbPath, threshold):
     generatedNumpyList = compNifti2numpy.main(str(pathlib.Path(inputNiftiPath)))
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList, limit=256)
     generatedObjPath = compNumpy2obj.main(
-        generatedNumpyList,
+        resizedNumpyList,
         threshold,
         str(compCommonPath.obj.joinpath("nifti2glb_tempObj.obj")),
     )

--- a/HoloPipelines/pipelines/pipelineNifti2glb.py
+++ b/HoloPipelines/pipelines/pipelineNifti2glb.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO)
 
 def main(inputNiftiPath, outputGlbPath, threshold):
     generatedNumpyList = compNifti2numpy.main(str(pathlib.Path(inputNiftiPath)))
-    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList, limit=256)
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList)
     generatedObjPath = compNumpy2obj.main(
         resizedNumpyList,
         threshold,

--- a/HoloPipelines/pipelines/pipelineNifti2obj.py
+++ b/HoloPipelines/pipelines/pipelineNifti2obj.py
@@ -1,6 +1,7 @@
 # this pipeline may be removed in the future as obj is not used to display 3D model on hololens
 from components import compNifti2numpy
 from components import compNumpy2obj
+from components import compNumpyTransformation
 import pathlib
 import sys
 import logging
@@ -10,8 +11,9 @@ logging.basicConfig(level=logging.INFO)
 
 def main(inputNiftiPath, outputObjPath, threshold, flipNpy=False):
     generatedNumpyList = compNifti2numpy.main(str(pathlib.Path(inputNiftiPath)))
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList, limit=256)
     generatedObjPath = compNumpy2obj.main(
-        generatedNumpyList, threshold, str(pathlib.Path(outputObjPath))
+        resizedNumpyList, threshold, str(pathlib.Path(outputObjPath))
     )
     logging.info("nifti2obj: done, obj saved to {}".format(generatedObjPath))
 

--- a/HoloPipelines/pipelines/pipelineNifti2obj.py
+++ b/HoloPipelines/pipelines/pipelineNifti2obj.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO)
 
 def main(inputNiftiPath, outputObjPath, threshold, flipNpy=False):
     generatedNumpyList = compNifti2numpy.main(str(pathlib.Path(inputNiftiPath)))
-    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList, limit=256)
+    resizedNumpyList = compNumpyTransformation.sizeLimit(generatedNumpyList)
     generatedObjPath = compNumpy2obj.main(
         resizedNumpyList, threshold, str(pathlib.Path(outputObjPath))
     )


### PR DESCRIPTION
- add resize function call from compNumpyTransforamtion in the rest of the pipelines (abdomen already has this)
- all pipelines except for abdomen pipeline now has resolution limit of 256
- add logging info for marching cube (time taken and face count)
- minor fix with dicom rotation

This is to address issue from #47. 