### PR TITLE
PIPELINE: gunicorn entrypoint

### DIFF
--- a/HoloPipelines/server.py
+++ b/HoloPipelines/server.py
@@ -17,7 +17,12 @@ from jobs.jobs_state import activate_periodic_garbage_collection, get_current_st
 from jobs.jobs_io import read_log_file_for_job, init_create_job_state_root_directories
 
 log_format = "%(asctime)s | %(name)s | %(levelname)s | %(message)s'"
-coloredlogs.install(level=logging.DEBUG, fmt=log_format)
+coloredlogs.install(level=logging.INFO, fmt=log_format)
+
+# Note: Code to run at import time, see https://stackoverflow.com/a/44406384/8495954
+logging.info("Running setup from server.py")
+init_create_job_state_root_directories()
+activate_periodic_garbage_collection()
 
 app = Flask(__name__)
 app.config["JSON_ADD_STATUS"] = False
@@ -70,6 +75,4 @@ def get_job_log(job_id: str):
 
 
 if __name__ == "__main__":
-    init_create_job_state_root_directories()
-    activate_periodic_garbage_collection()
     app.run(debug=FLASK_ENV == "development", port=APP_PORT)


### PR DESCRIPTION
When you run the server through gunicorn, the `__main__` doesn't run, so to fix that I followed the SO recommendation and put the initialisation to the top level (so it happens at import time)

However I am not sure if this is the right way to go. I haven't really verified it running in the gunicorn Docker container, as my computer is terribly slow. I think it may be a problem if/when we start gunicorn with multiple workers.

If we keep gunicorn workers at 1, as we have now, and start multiple processes in our own code, it should be fine? I noticed that when I just run Flask without gunicorn in development mode, it uses two processes, whereas when i run it with FLASK_ENV=production, it uses only 1. When I had two, they both tried to do the garbage collection file deletion. I added some error handling in #72 to solve that problem.