### PR TITLE
UI/BE: Use variables from process.env

### DIFF
--- a/HoloRepositoryUI/server/.env.local
+++ b/HoloRepositoryUI/server/.env.local
@@ -1,4 +1,5 @@
 # Refer to README for more infos
+APP_ID=holorepository-ui-server
 PORT=3001
 LOG_LEVEL=info
 REQUEST_LIMIT=100kb

--- a/HoloRepositoryUI/server/src/api/routes/patients/patients.service.ts
+++ b/HoloRepositoryUI/server/src/api/routes/patients/patients.service.ts
@@ -14,7 +14,6 @@ export class PatientsService {
     return FhirClient.getAllAndMap<R4.IPatient, IPatient>(SupportedFhirResourceType.Patient, {
       "general-practitioner": practitionerId
     });
-
   }
 
   public getById(pid: string): Promise<IPatient> {

--- a/HoloRepositoryUI/server/src/common/clients/HoloPipelinesClient.ts
+++ b/HoloRepositoryUI/server/src/common/clients/HoloPipelinesClient.ts
@@ -1,7 +1,6 @@
-const accessorBaseUrl = "http://localhost";
-const port = 3100;
+const { HOLOPIPELINES_HOST, HOLOPIPELINES_PORT } = process.env;
 const apiPrefix = `api/v1`;
-const baseURL = `${accessorBaseUrl}:${port}/${apiPrefix}`;
+const baseURL = `${HOLOPIPELINES_HOST}:${HOLOPIPELINES_PORT}/${apiPrefix}`;
 
 const getJobURL = (): string => {
   return `${baseURL}/job`;

--- a/HoloRepositoryUI/server/src/common/clients/HoloStorageAccesorClient.ts
+++ b/HoloRepositoryUI/server/src/common/clients/HoloStorageAccesorClient.ts
@@ -1,8 +1,7 @@
-const accessorBaseUrl = "http://localhost";
-const port = 3200;
+const { HOLOSTORAGE_ACCESSOR_HOST, HOLOSTORAGE_ACCESSOR_PORT } = process.env;
+
 const apiPrefix = `api/v1`;
-const hologramsEndpoint = "holograms";
-const baseURL = `${accessorBaseUrl}:${port}/${apiPrefix}/${hologramsEndpoint}`;
+const baseURL = `${HOLOSTORAGE_ACCESSOR_HOST}:${HOLOSTORAGE_ACCESSOR_PORT}/${apiPrefix}/holograms`;
 
 const getBaseURL = () => baseURL;
 

--- a/HoloRepositoryUI/server/src/common/logger.ts
+++ b/HoloRepositoryUI/server/src/common/logger.ts
@@ -1,8 +1,12 @@
 import pino from "pino";
 
+const { APP_ID, LOG_LEVEL } = process.env;
+
 const logger = pino({
-  name: process.env.APP_ID || "",
-  level: process.env.LOG_LEVEL || "debug"
+  // Note: Default values needed as this runs before any test setup,
+  // and will run as dependency of other components
+  name: APP_ID || "holorepository-ui-server",
+  level: LOG_LEVEL || "debug"
 });
 
 export default logger;

--- a/HoloRepositoryUI/server/src/common/server.ts
+++ b/HoloRepositoryUI/server/src/common/server.ts
@@ -8,7 +8,7 @@ import cors from "cors";
 
 const app = express();
 
-const { PORT: port, REQUEST_LIMIT: limit } = process.env;
+const { NODE_ENV, PORT, REQUEST_LIMIT } = process.env;
 const rootPath = path.normalize(__dirname + "/../..");
 const staticFilesPath = `${rootPath}/public`;
 
@@ -18,8 +18,8 @@ export default class ExpressServer {
     app.set("appPath", rootPath);
 
     // Set configuration
-    app.use(bodyParser.json({ limit }));
-    app.use(bodyParser.urlencoded({ extended: true, limit }));
+    app.use(bodyParser.json({ limit: REQUEST_LIMIT }));
+    app.use(bodyParser.urlencoded({ extended: true, limit: REQUEST_LIMIT }));
 
     // Serve static assets
     app.use(express.static(staticFilesPath));
@@ -40,10 +40,8 @@ export default class ExpressServer {
 
   public listen(): Application {
     const welcomeMessage = () =>
-      logger.info(
-        `Up and running in ${process.env.NODE_ENV} @: ${os.hostname()} on port: ${port}}`
-      );
-    http.createServer(app).listen(port, welcomeMessage);
+      logger.info(`Up and running in ${NODE_ENV} @: ${os.hostname()} on port: ${PORT}}`);
+    http.createServer(app).listen(PORT, welcomeMessage);
     return app;
   }
 }


### PR DESCRIPTION
That was dumb 🤕 Some variables, even though they were already prepared in `.env`, were not actually accessed through the environment variable.