### PR TITLE
PIPELINE: Use HTTP client in receive_input task

### DIFF
--- a/HoloPipelines/core/clients/http.py
+++ b/HoloPipelines/core/clients/http.py
@@ -2,7 +2,7 @@
 This module contains provides a generic HTTP client with helper methods for
 fetching data from the web.
 """
-
+import io
 import logging
 from zipfile import ZipFile
 
@@ -26,7 +26,7 @@ def unzip_file(zipped_data: bytes, output_directory_path: str) -> None:
     """
     Unzips a file to a given directory.
     """
-    with ZipFile(bytes) as zip_file:
+    with ZipFile(io.BytesIO(zipped_data)) as zip_file:
         zip_file.extractall(output_directory_path)
         logging.info(f"Successfully extracted to '{output_directory_path}'")
 

--- a/HoloPipelines/core/clients/http.py
+++ b/HoloPipelines/core/clients/http.py
@@ -2,20 +2,38 @@
 This module contains provides a generic HTTP client with helper methods for
 fetching data from the web.
 """
-import io
+
 import logging
 from zipfile import ZipFile
 
 import requests
 
 
+def fetch_input_from_url(url_to_zip_file: str) -> bytes:
+    """
+    Fetches a zipped resource and returns the content.
+    :return resource content as bytes
+    """
+    response = requests.get(url_to_zip_file)
+    if response.status_code != 200:
+        raise Exception(f"HTTP response {response.status_code}: {response.content}")
+
+    logging.info(f"Download of '{url_to_zip_file}' was successful")
+    return response.content
+
+
+def unzip_file(zipped_data: bytes, output_directory_path: str) -> None:
+    """
+    Unzips a file to a given directory.
+    """
+    with ZipFile(bytes) as zip_file:
+        zip_file.extractall(output_directory_path)
+        logging.info(f"Successfully extracted to '{output_directory_path}'")
+
+
 def download_and_unzip(url_to_zip_file: str, output_directory_path: str) -> None:
     """
     Fetches a zip resource and unpacks it. The zip file itself is only read in-memory.
     """
-    response = requests.get(url_to_zip_file)
-    logging.info(f"Download of '{url_to_zip_file}' was successful")
-
-    with ZipFile(io.BytesIO(response.content)) as zip_file:
-        zip_file.extractall(output_directory_path)
-        logging.info(f"Successfully extracted to '{output_directory_path}'")
+    input_zip_bytes = fetch_input_from_url(url_to_zip_file)
+    unzip_file(input_zip_bytes, output_directory_path)

--- a/HoloPipelines/core/tasks/shared/receive_input.py
+++ b/HoloPipelines/core/tasks/shared/receive_input.py
@@ -2,35 +2,11 @@
 This module contains the functions that upon starting a pipeline go and
 fetch the input imaging studies from a PACS.
 """
-
-import io
-from zipfile import ZipFile
-
-import requests
-
-
-def fetch_input_from_url(url: str) -> bytes:
-    """
-    Fetches and returns a resource.
-    """
-    response = requests.get(url)
-    if response.status_code != 200:
-        raise Exception(f"HTTP response {response.status_code}: {response.content}")
-    return response.content
-
-
-def unzip_file(zipped_data: bytes, output_directory: str) -> None:
-    """
-    Unzips a file to a given directory.
-    """
-    with ZipFile(io.BytesIO(zipped_data)) as zipped_file:
-        zipped_file.extractall(output_directory)
+from core.clients.http import download_and_unzip
 
 
 def fetch_and_unzip(imaging_study_endpoint: str, input_directory_path: str) -> None:
     """
-    Fetches and unpacks a zipped resource. Input is a DICOM directory stored in a
-    zip. Notice how the resource is kept in-memory prior to unzipping.
+    Fetches and unpacks a zipped resource. Input is a DICOM directory stored in a zip.
     """
-    input_zip = fetch_input_from_url(imaging_study_endpoint)
-    unzip_file(input_zip, input_directory_path)
+    download_and_unzip(imaging_study_endpoint, input_directory_path)


### PR DESCRIPTION
`http_client` was extracted in a PR. I then realised that I introduced duplicate code, so refactored it.

PS: The "shared tasks" are currently really only redirecting to other components. I think it's okay to leave it as is, and was thinking that in the future they can be used to make the pipelines even more generic (always just plug together a couple of tasks, without knowing if it's a wrapper, client, service...) but if it bothers you in its current state, they could be removed and replaced with the direct calls in the pipelines.